### PR TITLE
Tca dependencies

### DIFF
--- a/TCAWorkshop/TCAWorkshop/MeetingRoom/AvailableMeetingRoom/AvailableMeetingRoomDomain.swift
+++ b/TCAWorkshop/TCAWorkshop/MeetingRoom/AvailableMeetingRoom/AvailableMeetingRoomDomain.swift
@@ -12,6 +12,9 @@ struct AvailableMeetingRoomFeature: Reducer {
     @Dependency(\.meetingRoomClient)
     var meetingRoomClient: MeetingRoomClient
     
+    @Dependency(\.continuousClock)
+    var clock: any Clock<Duration>
+    
     struct State: Equatable, Identifiable {
         @BindingState var selectedMeetingRoom: MeetingRoom
         var id: UUID
@@ -49,7 +52,7 @@ struct AvailableMeetingRoomFeature: Reducer {
                     /// inout value type 의 Data race를 방지
                     return .run { [selectedMeetingRoom = state.selectedMeetingRoom] send in
                         try await self.meetingRoomClient.update(selectedMeetingRoom)
-                        try! await Task.sleep(for: .seconds(0.5))
+                        try await clock.sleep(for: .seconds(0.5))
                         await send(.reservationResponse, animation: .easeInOut)
                     } catch: { error, send in
                         print("UPDATE FAILED", error.localizedDescription)

--- a/TCAWorkshop/TCAWorkshop/MeetingRoom/BookedMeetingRoom/BookedMeetingRoomDomain.swift
+++ b/TCAWorkshop/TCAWorkshop/MeetingRoom/BookedMeetingRoom/BookedMeetingRoomDomain.swift
@@ -12,6 +12,9 @@ struct BookedMeetingRoomFeature: Reducer {
     @Dependency(\.meetingRoomClient)
     var meetingRoomClient: MeetingRoomClient
     
+    @Dependency(\.continuousClock)
+    var clock: any Clock<Duration>
+    
     struct State: Equatable, Identifiable {
         @BindingState var selectedMeetingRoom: MeetingRoom
         var id: UUID
@@ -47,7 +50,7 @@ struct BookedMeetingRoomFeature: Reducer {
                     
                     return .run { [selectedMeetingRoom = state.selectedMeetingRoom] send in
                         try await meetingRoomClient.update(selectedMeetingRoom)
-                        try! await Task.sleep(for: .seconds(0.5))
+                        try await clock.sleep(for: .seconds(0.5))
                         await send(.cancelReservationResponse, animation: .easeInOut)
                     } catch: { error, send in
                         print("RESERVATION CANCEL FAILED", error.localizedDescription)

--- a/TCAWorkshop/TCAWorkshop/MeetingRoom/MeetingRoomListDomain.swift
+++ b/TCAWorkshop/TCAWorkshop/MeetingRoom/MeetingRoomListDomain.swift
@@ -14,6 +14,9 @@ struct MeetingRoomListDomain: Reducer {
     @Dependency(\.meetingRoomClient)
     var firebaseClient: MeetingRoomClient
     
+    @Dependency(\.continuousClock)
+    var clock: any Clock<Duration>
+    
     struct State: Equatable {
         var availableMeetingRoomArray: IdentifiedArrayOf<AvailableMeetingRoomFeature.State> = []
         var unavailableMeetingRoomArray: IdentifiedArrayOf<UnavabilableMeetingRoomFeature.State> = []
@@ -29,6 +32,8 @@ struct MeetingRoomListDomain: Reducer {
         var isAvailableMeetingRoomArrayEmpty: Bool = true
         var isUnavailableMeetingRoomArrayEmpty: Bool = true
         var isBookedMeetingRoomArrayEmpty: Bool = true
+        
+        var takeLongLongTimeTaskResult: String = ""
     }
     
     @frozen enum Action: Equatable {
@@ -57,6 +62,9 @@ struct MeetingRoomListDomain: Reducer {
         case listRefreshed
         case confirmationDialogRetryButtonTapped
         case confirmationDialogDismissed(Bool)
+        
+        case takeLongLongTimeTaskButtonTapped
+        case takeLongLongTimeTaskResponse(String)
     }
     
     var body: some ReducerOf<Self> {
@@ -160,8 +168,11 @@ struct MeetingRoomListDomain: Reducer {
                 
                 return .run { send in
                     let fetchedMeetingRooms = try await self.firebaseClient.fetch()
-                    try await Task.sleep(for: .seconds(0.5))
-                    await send(.meetingRoomFetchComplete, animation: .easeInOut)
+                    try await clock.sleep(for: .seconds(0.5))
+                    await send(
+                        .processFetchedMeetingRooms(with: fetchedMeetingRooms),
+                        animation: .easeInOut
+                    )
                 }
                 catch: { error, send in
                     print("FETCH FAILED AGAIN: ", error)
@@ -175,6 +186,16 @@ struct MeetingRoomListDomain: Reducer {
             case .fetchUnavailableResponse:
                 state.isFetchAvailable = false
                 state.isMeetingRoomFetching = false
+                return .none
+                
+            case .takeLongLongTimeTaskButtonTapped:
+                return .run { send in
+                    try await clock.sleep(for: .seconds(120))
+                    print("정말 오래 걸렸다!")
+                    await send(.takeLongLongTimeTaskResponse("COMPLETE"))
+                }
+            case let .takeLongLongTimeTaskResponse(result):
+                state.takeLongLongTimeTaskResult = result
                 return .none
             }
         }

--- a/TCAWorkshop/TCAWorkshop/MeetingRoom/MeetingRoomListView.swift
+++ b/TCAWorkshop/TCAWorkshop/MeetingRoom/MeetingRoomListView.swift
@@ -25,6 +25,13 @@ struct RootView: View {
                             by: viewStore.state
                         )
                     }
+                    
+                    Button {
+                        //
+                    } label: {
+                        Text("정말 오래 걸리는 작업!")
+                    }
+
                 }
                 .onAppear {
                     viewStore.send(.onMeetingRoomListViewAppear)
@@ -171,7 +178,7 @@ struct RootView_Previews: PreviewProvider {
         NavigationStack {
             RootView(
                 store: Store(
-                    initialState: MeetingRoomListDomain.State(isFetchAvailable: false)
+                    initialState: MeetingRoomListDomain.State()
                 ) {
                     // PREVIEW는 Test용으로 client를 초기화합니다.
                     MeetingRoomListDomain()

--- a/TCAWorkshop/Tests/TCAWorkshopTests/TCAWorkshopTests.swift
+++ b/TCAWorkshop/Tests/TCAWorkshopTests/TCAWorkshopTests.swift
@@ -71,4 +71,30 @@ final class TCAWorkshopTests: XCTestCase {
             $0.isMeetingRoomInitOnce = true
         }
     }
+    
+    func testTakeLongLongTimeTask() async throws {
+        let store = TestStore(initialState: MeetingRoomListDomain.State()) {
+            MeetingRoomListDomain()
+        } withDependencies: {
+            $0.continuousClock = ContinuousClock()
+        }
+        
+        await store.send(.takeLongLongTimeTaskButtonTapped)
+        await store.receive(.takeLongLongTimeTaskResponse("COMPLETE"), timeout: .seconds(120.0)) {
+            $0.takeLongLongTimeTaskResult = "COMPLETE"
+        }
+    }
+    
+    func testTakeLongLongTimeTaskInShort() async throws {
+        let store = TestStore(initialState: MeetingRoomListDomain.State()) {
+            MeetingRoomListDomain()
+        } withDependencies: {
+            $0.continuousClock = ImmediateClock()
+        }
+        
+        await store.send(.takeLongLongTimeTaskButtonTapped)
+        await store.receive(.takeLongLongTimeTaskResponse("COMPLETE"), timeout: .seconds(1.0)) {
+            $0.takeLongLongTimeTaskResult = "COMPLETE"
+        }
+    }
 }


### PR DESCRIPTION
- `Task.sleep()` 을 대체할 수 있는 `clock.sleep()` 의존성 추가
- 각 View에 달려있던 Task.sleep을 대체!
- Test 코드에서 `ContinuousClock()`, `ImmediateClock()` 의 테스트 차이를 보여줄 수 있도록 2개의 테스트 예시 작성